### PR TITLE
Deleted jekyll tag generating metatag that's problematic for google SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-robots: noindex
 ---
 
 <div class="main-post-list">


### PR DESCRIPTION
I think it is generating <meta name="robots" content="noindex">
Give me a note when it will be on production or tell google to fetch new site: https://support.google.com/webmasters/answer/6066468?hl=pl

Currently our google search is awful. First website with hackerspace is http://codeme.pl/hackerspace/
but there are 404 of every static file.