### PR TITLE
Remove duplicated menu in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,18 +1,4 @@
 <footer>
-    <section class="footer__navigation">
-        <a href="{{ site.baseurl }}/">
-            <img src="/assets/50x50_logo_small.png" alt="HS">
-        </a>
-
-        <nav class="navigation">
-            {% include nav-links.html menu=site.menus.header %}
-        </nav>
-        <nav class="socials">
-            {% include nav-links.html menu=site.menus.quick %}
-        </nav>
-
-    </section>
-    
     <section class="footer__notice">
         <p>&#9400; Hackerspace Trójmiasto.</p>
         <p>Nie działa?

--- a/_sass/partials/_footer.scss
+++ b/_sass/partials/_footer.scss
@@ -23,7 +23,6 @@ footer {
 
     section {
         padding: 1em 3em;
-        margin-top: 1em;
     }
 
     .footer__notice {


### PR DESCRIPTION
Most of sites are currently quite short, so there is no need for
footer so big. We can revert it when sites grows.